### PR TITLE
Avoid already initialized constant error

### DIFF
--- a/lib/puppet-lint/plugins/top_scope_facts.rb
+++ b/lib/puppet-lint/plugins/top_scope_facts.rb
@@ -1,9 +1,9 @@
 PuppetLint.new_check(:top_scope_facts) do
-  VAR_TYPES = Set[:VARIABLE, :UNENC_VARIABLE]
+  TOP_SCOPE_FACTS_VAR_TYPES = Set[:VARIABLE, :UNENC_VARIABLE]
   def check
     whitelist = ['trusted', 'facts'] + (PuppetLint.configuration.top_scope_variables || [])
     whitelist = whitelist.join('|')
-    tokens.select { |x| VAR_TYPES.include?(x.type) }.each do |token|
+    tokens.select { |x| TOP_SCOPE_FACTS_VAR_TYPES.include?(x.type) }.each do |token|
       if token.value.match(/^::/) and not token.value.match(/^::(#{whitelist})\[?/)
         notify :warning, {
           :message => 'top scope fact instead of facts hash',


### PR DESCRIPTION
A simple workaround to avoid the following warning message:

```
~/.pdk/cache/ruby/2.1.0/gems/puppet-lint-legacy_facts-check-1.0.1/lib/puppet-lint/plugins/legacy_facts.rb:2: warning: already initialized constant VAR_TYPES
/opt/puppetlabs/pdk/share/cache/ruby/2.1.0/gems/puppet-lint-2.3.6/lib/puppet-lint/plugins/check_strings/only_variable_string.rb:6: warning: previous definition of VAR_TYPES was here
```
